### PR TITLE
feat(builder-interface): add sidebar with navigation options and internal components page

### DIFF
--- a/src/components/builder/builder.tsx
+++ b/src/components/builder/builder.tsx
@@ -21,13 +21,17 @@ import {
   StepStatus,
   templateAPIResponse,
 } from "@/types";
+import { Sidebar } from "../ui/sidebar/sidebar";
+import { InternalComponents } from "./sections/InternalComponents";
 
 export default function Builder() {
   const searchParams = useSearchParams();
+  const [isExpanded, setIsExpanded] = useState(true);
   const query = searchParams.get("query");
   const [selectedFile, setSelectedFile] = useState<FileNode | null>(null);
   const [fileNode, setFileNode] = useState<FileNode[]>([]);
   const [steps, setSteps] = useState<Step[]>([]);
+  const [currentPage, setCurrentPage] = useState<'code-editor' | 'components'>('code-editor');
   const [activeView, setActiveView] = useState<'editor' | 'preview'>('editor');
   const webcontainerState = useWebContainer(fileNode);
 
@@ -54,11 +58,21 @@ export default function Builder() {
   }, []);
 
   
-  return (
+  return (<>
+
+    <Navbar template={steps as Step[]} />
+    <div className="min-h-screen bg-gray-100 flex">
+    <Sidebar 
+      isExpanded={isExpanded} 
+      onToggle={() => setIsExpanded(!isExpanded)} 
+      onNavigate={setCurrentPage}
+      currentPage={currentPage}
+    />
+    {/* Main Content */}
+    <div className="flex-1">
     <div className="flex flex-col h-screen overflow-hidden">
-      <Navbar template={steps as Step[]} />
+    {currentPage === 'code-editor' ? (
       <div className="flex-1 bg-gray-900 text-white flex overflow-hidden">
-        {/* Steps sidebar */}
         <div className="h-full flex flex-col w-[40%]">
           <div className="flex flex-1 overflow-hidden">
             <ProgressSteps steps={steps.length > 0 ? steps : PROGRESS_STEPS} />
@@ -97,6 +111,12 @@ export default function Builder() {
           </div>
         </div>
       </div>
+    ):(<InternalComponents />) 
+  }
     </div>
+    </div>
+  </div>
+  </>
+
   );
 }

--- a/src/components/builder/sections/InternalComponents.tsx
+++ b/src/components/builder/sections/InternalComponents.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { ComponentCard } from '@/components/ui/card-component/card-component';
+import { ComponentDetail } from '@/components/ui/details-component/details-component';
+
+
+export interface Component {
+    componentName: string;
+    indexingStatus: boolean;
+    componentPath: string;
+    description: string;
+    useCase: string;
+    codeSamples: string[];
+    dependencies: string[];
+    importPath: string;
+  }
+
+  const components: Component[] = [
+    {
+      componentName: 'Button',
+      indexingStatus: true,
+      componentPath: '/src/components/Button',
+      description: 'A versatile button component with multiple variants and sizes',
+      useCase: 'Used for triggering actions or submitting forms',
+      codeSamples: [
+        '<Button variant="primary">Click me</Button>',
+        '<Button variant="secondary" size="sm">Small Button</Button>'
+      ],
+      dependencies: ['react', 'tailwindcss'],
+      importPath: '@/components/Button'
+    },
+    {
+      componentName: 'Card',
+      indexingStatus: true,
+      componentPath: '/src/components/Card',
+      description: 'A flexible card component for displaying content in a contained format',
+      useCase: 'Displaying grouped information in a visually appealing way',
+      codeSamples: ['<Card title="Example">Content goes here</Card>'],
+      dependencies: ['react', 'tailwindcss'],
+      importPath: '@/components/Card'
+    },
+    {
+      componentName: 'Input',
+      indexingStatus: false,
+      componentPath: '/src/components/Input',
+      description: 'An input component with built-in validation and error handling',
+      useCase: 'Form inputs with validation support',
+      codeSamples: ['<Input type="text" placeholder="Enter your name" />'],
+      dependencies: ['react', 'tailwindcss'],
+      importPath: '@/components/Input'
+    },
+    {
+      componentName: 'Modal',
+      indexingStatus: true,
+      componentPath: '/src/components/Modal',
+      description: 'A modal dialog component with backdrop and animation',
+      useCase: 'Displaying important information or confirmations',
+      codeSamples: ['<Modal isOpen={true} onClose={() => {}}>Modal content</Modal>'],
+      dependencies: ['react', 'tailwindcss'],
+      importPath: '@/components/Modal'
+    }
+  ];
+
+export function InternalComponents() {
+  const [selectedComponent, setSelectedComponent] = useState<Component | null>(null);
+
+  return (
+    <div className="p-8 bg-gray-900 h-screen">
+      <h1 className="text-2xl font-semibold text-white mb-6">Internal Components</h1>
+      <div className="flex flex-wrap">
+        {components.map((component) => (
+        <div key={component.componentName}className='w-1/2 p-8' >
+          <ComponentCard
+            key={component.componentName}
+            component={component}
+            onClick={() => setSelectedComponent(component)}
+            />
+        </div>
+        ))}
+      </div>
+
+      {selectedComponent && (
+        <ComponentDetail
+          component={selectedComponent}
+          onClose={() => setSelectedComponent(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/card-component/card-component.tsx
+++ b/src/components/ui/card-component/card-component.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ChevronRight, CheckCircle, XCircle } from 'lucide-react';
+
+export interface Component {
+    componentName: string;
+    indexingStatus: boolean;
+    componentPath: string;
+    description: string;
+    useCase: string;
+    codeSamples: string[];
+    dependencies: string[];
+    importPath: string;
+  }
+
+interface ComponentCardProps {
+  component: Component;
+  onClick: () => void;
+}
+
+export function ComponentCard({ component, onClick }: ComponentCardProps) {
+  return (
+    <div className="bg-blue-900  rounded-lg shadow-md p-6 max-w-full max-h-full hover:shadow-lg transition-shadow" >
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-center gap-2 ">
+            <h3 className="text-lg font-semibold ">{component.componentName}</h3>
+            {component.indexingStatus ? (
+              <CheckCircle className="w-4 h-4 text-green-500" />
+            ) : (
+              <XCircle className="w-4 h-4 text-red-500" />
+            )}
+          </div>
+          <p className="line-clamp-2 mt-4 p-2">Use Case: {component.useCase.substring(0,30)}...</p>
+          <p className="line-clamp-2 mt-4 p-2">Description: {component.description.substring(0,60)}...</p>
+        </div>
+      </div>
+      
+      
+      <button
+        onClick={onClick}
+        className="mt-4 flex items-center p-2 bg-amber-300 rounded-lg text-blue-900 hover:bg-amber-200 hover:cursor-pointer transition-colors  font-semibold"
+      >
+        Read more
+        <ChevronRight className="w-4 h-4 ml-1" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/details-component/details-component.tsx
+++ b/src/components/ui/details-component/details-component.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { X, CheckCircle, XCircle } from 'lucide-react';
+
+export interface Component {
+  componentName: string;
+  indexingStatus: boolean;
+  componentPath: string;
+  description: string;
+  useCase: string;
+  codeSamples: string[];
+  dependencies: string[];
+  importPath: string;
+}
+
+interface ComponentDetailProps {
+  component: Component;
+  onClose: () => void;
+}
+
+export function ComponentDetail({ component, onClose }: ComponentDetailProps) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+        <div className="p-6">
+          <div className="flex items-start justify-between">
+            <div className="flex items-center gap-2">
+              <h2 className="text-2xl font-semibold text-gray-800">{component.componentName}</h2>
+              {component.indexingStatus ? (
+                <CheckCircle className="w-5 h-5 text-green-500" />
+              ) : (
+                <XCircle className="w-5 h-5 text-red-500" />
+              )}
+            </div>
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-700 transition-colors"
+            >
+              <X className="w-6 h-6" />
+            </button>
+          </div>
+
+          <div className="mt-6 space-y-6">
+            <div>
+              <h3 className="text-lg font-medium text-gray-800">Component Path</h3>
+              <p className="mt-1 text-gray-600">{component.componentPath}</p>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-medium text-gray-800">Description</h3>
+              <p className="mt-1 text-gray-600">{component.description}</p>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-medium text-gray-800">Use Case</h3>
+              <p className="mt-1 text-gray-600">{component.useCase}</p>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-medium text-gray-800">Import Path</h3>
+              <code className="mt-1 block bg-gray-100 p-2 rounded text-sm">{component.importPath}</code>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-medium text-gray-800">Code Samples</h3>
+              <div className="mt-2 space-y-2">
+                {component.codeSamples.map((sample, index) => (
+                  <code key={index} className="block bg-gray-100 p-2 rounded text-sm">
+                    {sample}
+                  </code>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-medium text-gray-800">Dependencies</h3>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {component.dependencies.map((dep, index) => (
+                  <span
+                    key={index}
+                    className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm"
+                  >
+                    {dep}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/navbar/navbar.tsx
+++ b/src/components/ui/navbar/navbar.tsx
@@ -4,10 +4,6 @@ import { Step } from "@/types";
 import { exportToZip } from "@/lib/utils/exportFolder";
 import { SuccessPopup } from "../success-popup/sucess-popup";
 
-interface SettingsModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
 
 interface NavbarProps {
   template: Step[];
@@ -22,110 +18,9 @@ function IndexingIndicator() {
   );
 }
 
-function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
-  const [repoUrl, setRepoUrl] = useState("");
-  const [authToken, setAuthToken] = useState("");
-  const [showInternalConfig, setShowInternalConfig] = useState(false);
 
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-md">
-        <div className="flex items-center justify-between p-4 border-b">
-          <h2 className="text-xl font-semibold text-gray-800">Settings</h2>
-          <button
-            onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 transition-colors"
-          >
-            <X size={20} />
-          </button>
-        </div>
-        <div className="p-4 space-y-4">
-          <div className="flex items-center justify-between py-2">
-            <div className="flex flex-col">
-              <span className="text-sm font-medium text-gray-700">
-                Configure Internal Components
-              </span>
-              <span className="text-xs text-gray-500">
-                Enable to configure GitHub repository settings
-              </span>
-            </div>
-            <button
-              onClick={() => setShowInternalConfig(!showInternalConfig)}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
-                showInternalConfig ? "bg-blue-600" : "bg-gray-200"
-              }`}
-            >
-              <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                  showInternalConfig ? "translate-x-6" : "translate-x-1"
-                }`}
-              />
-            </button>
-          </div>
-
-          {showInternalConfig && (
-            <>
-              <div className="space-y-2">
-                <label
-                  htmlFor="repoUrl"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  GitHub Repository URL
-                </label>
-                <input
-                  id="repoUrl"
-                  type="text"
-                  value={repoUrl}
-                  onChange={(e) => setRepoUrl(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 text-black focus:ring-blue-500 focus:border-blue-500"
-                  placeholder="https://github.com/username/repo"
-                />
-              </div>
-              <div className="space-y-2">
-                <label
-                  htmlFor="authToken"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  GitHub Authorization Token (optional)
-                </label>
-                <input
-                  id="authToken"
-                  type="password"
-                  value={authToken}
-                  onChange={(e) => setAuthToken(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 text-black focus:ring-blue-500 focus:border-blue-500"
-                  placeholder="ghp_xxxxxxxxxxxx"
-                />
-              </div>
-            </>
-          )}
-        </div>
-        <div className="flex justify-end gap-3 p-4 border-t">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-800 transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={() => {
-              // Handle save logic here
-              onClose();
-            }}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
-          >
-            Save Changes
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export function Navbar({ template }: NavbarProps) {
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [successPopup, setSuccessPopup] = useState(false);
   const handleExport = async () => {
     const status = await exportToZip({ template });
@@ -134,7 +29,7 @@ export function Navbar({ template }: NavbarProps) {
   };
   return (
     <>
-      <nav className="bg-[#0A1A2F] border-b border-[#1E3A5F]">
+      <nav className="bg-[#0A1A2F] border-b border-[#1E3A5F] px-4">
         <div className=" mx-2">
           <div className="flex justify-between h-16">
             <div className="flex items-center">
@@ -153,21 +48,12 @@ export function Navbar({ template }: NavbarProps) {
                 Export
               </button>
 
-              <button
-                onClick={() => setIsSettingsOpen(true)}
-                className="p-2 text-gray-300 hover:text-white rounded-md hover:bg-[#1E3A5F] transition-colors"
-                title="Settings"
-              >
-                <Settings size={20} />
-              </button>
+ 
             </div>
           </div>
         </div>
       </nav>
-      <SettingsModal
-        isOpen={isSettingsOpen}
-        onClose={() => setIsSettingsOpen(false)}
-      />
+
       {successPopup && <SuccessPopup />}
     </>
   );

--- a/src/components/ui/sidebar/sidebar.tsx
+++ b/src/components/ui/sidebar/sidebar.tsx
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+import { Menu, Code, Layout, Settings, X } from 'lucide-react';
+
+interface SidebarProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+  onNavigate: (page:'code-editor' | 'components') => void;
+  currentPage: string;
+}
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+    const [repoUrl, setRepoUrl] = useState("");
+    const [authToken, setAuthToken] = useState("");
+    const [showInternalConfig, setShowInternalConfig] = useState(false);
+  
+    if (!isOpen) return null;
+  
+    return (
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="bg-white rounded-lg shadow-xl w-full max-w-md">
+          <div className="flex items-center justify-between p-4 border-b">
+            <h2 className="text-xl font-semibold text-gray-800">Settings</h2>
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-700 transition-colors"
+            >
+              <X size={20} />
+            </button>
+          </div>
+          <div className="p-4 space-y-4">
+            <div className="flex items-center justify-between py-2">
+              <div className="flex flex-col">
+                <span className="text-sm font-medium text-gray-700">
+                  Configure Internal Components
+                </span>
+                <span className="text-xs text-gray-500">
+                  Enable to configure GitHub repository settings
+                </span>
+              </div>
+              <button
+                onClick={() => setShowInternalConfig(!showInternalConfig)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                  showInternalConfig ? "bg-blue-600" : "bg-gray-200"
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    showInternalConfig ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            </div>
+  
+            {showInternalConfig && (
+              <>
+                <div className="space-y-2">
+                  <label
+                    htmlFor="repoUrl"
+                    className="block text-sm font-medium text-gray-700"
+                  >
+                    GitHub Repository URL
+                  </label>
+                  <input
+                    id="repoUrl"
+                    type="text"
+                    value={repoUrl}
+                    onChange={(e) => setRepoUrl(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 text-black focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="https://github.com/username/repo"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label
+                    htmlFor="authToken"
+                    className="block text-sm font-medium text-gray-700"
+                  >
+                    GitHub Authorization Token (optional)
+                  </label>
+                  <input
+                    id="authToken"
+                    type="password"
+                    value={authToken}
+                    onChange={(e) => setAuthToken(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-2 text-black focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="ghp_xxxxxxxxxxxx"
+                  />
+                </div>
+              </>
+            )}
+          </div>
+          <div className="flex justify-end gap-3 p-4 border-t">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-800 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => {
+                // Handle save logic here
+                onClose();
+              }}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
+            >
+              Save Changes
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+export function Sidebar({ isExpanded, onToggle, onNavigate, currentPage }: SidebarProps) {
+      const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  return (
+    <div 
+      className={` bg-[#0A1A2F] border-b  border-[#1E3A5F] shadow-lg transition-all duration-300 ${
+        isExpanded ? 'w-64' : 'w-16'
+      }`}
+    >
+      <button
+        onClick={onToggle}
+        className="p-4 hover:bg-[#1E3A5F] transition-colors"
+      >
+        <Menu className="w-6 h-6 text-white" />
+      </button>
+
+      <div className="flex-1 py-4">
+        <button className="w-full p-4 flex items-center gap-3 hover:bg-[#1E3A5F] transition-colors"   onClick={() => onNavigate('code-editor')}>
+          <Code className="w-6 h-6 text-white" />
+          {isExpanded && <span className="text-white">Code Editor</span>}
+        </button>
+        <button className="w-full p-4 flex items-center gap-3 hover:bg-[#1E3A5F] transition-colors"  onClick={() => onNavigate('components')}>
+          <Layout className="w-6 h-6 text-white" />
+          {isExpanded && <span className="text-white">Internal Components</span>}
+        </button>
+        <button onClick={() => setIsSettingsOpen(true)} className="w-full p-4 flex items-center gap-3 hover:bg-[#1E3A5F] transition-colors ">
+        <Settings className="w-6 h-6 text-white" />
+        {isExpanded && <span className="text-white">Settings </span> }
+       </button>
+      </div>
+      <SettingsModal
+        isOpen={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
- Added a sidebar with navigation options for:
	- Code Editor
	- Internal Components
  	- Settings
- Created the Internal Components page:
	- Displayed each component as a card.
  	- Implemented functionality to view detailed information for each component card.
 <img width="1464" alt="Screenshot 2025-03-26 at 2 14 24 AM" src="https://github.com/user-attachments/assets/8eaaa87f-10fd-4c21-b153-56b46e2a553e" />
- Enabled functionality to switch seamlessly between Code Editor and Internal Components views.